### PR TITLE
Tree Page model creation

### DIFF
--- a/app/models/operation.js
+++ b/app/models/operation.js
@@ -60,6 +60,9 @@
  *
  */
 
+var mongoose = require('mongoose');
+mongoose.connect('mongodb://localhost/test');
+
 var OperationSchema = mongoose.Schema({
   treeUrl: { type: String, required: true, trim: true },
   treeType: { type: String, required: true, trim: true },

--- a/app/models/tree_page.js
+++ b/app/models/tree_page.js
@@ -1,0 +1,18 @@
+/*
+ * TreePage
+ *
+ * This is the model that actually stores the html for a particular url.
+ *
+ */
+
+var mongoose = require('mongoose');
+mongoose.connect('mongodb://localhost/test');
+
+var TreePageSchema = mongoose.Schema({
+  treeUrl: { type: String, required: true, trim: true },
+  treeHtml: { type: String, required: true, trim: true }
+});
+
+var TreePage = mongoose.model('TreePage', TreePageSchema);
+
+exports.TreePage = TreePage;

--- a/app/models/tree_page.js
+++ b/app/models/tree_page.js
@@ -9,7 +9,7 @@ var mongoose = require('mongoose');
 mongoose.connect('mongodb://localhost/test');
 
 var TreePageSchema = mongoose.Schema({
-  treeKey: { type: String, required: true, trim: true},
+  treeKey: { type: String, required: true, index: { unique: true, sparse: true } },
   treeUrl: { type: String, required: true, trim: true },
   treeHtml: { type: String, required: true, trim: true }
 });

--- a/app/models/tree_page.js
+++ b/app/models/tree_page.js
@@ -9,6 +9,7 @@ var mongoose = require('mongoose');
 mongoose.connect('mongodb://localhost/test');
 
 var TreePageSchema = mongoose.Schema({
+  treeKey: { type: String, required: true, trim: true},
   treeUrl: { type: String, required: true, trim: true },
   treeHtml: { type: String, required: true, trim: true }
 });

--- a/app/tree-adapters/operation_processor.js
+++ b/app/tree-adapters/operation_processor.js
@@ -1,0 +1,18 @@
+/*
+ * Operation Processor
+ *
+ * This takes an operation and some html, and applies that operation onto
+ * the html.
+ *
+ */
+
+var OperationProcessor = function(opts) {
+  this.opts = opts || {};
+}
+
+OperationProcessor.prototype.operate(operation, html) {
+  // FIXME: implement this method
+  return html;
+}
+
+exports.OperationProcessor = OperationProcessor;

--- a/app/tree-adapters/url_storage.js
+++ b/app/tree-adapters/url_storage.js
@@ -1,0 +1,54 @@
+/*
+ * Url Storage Adapter
+ *
+ * This stores url and all operations associated with that url
+ *
+ */
+
+var OperationProcessor = require('./operation_processor').OperationProcessor;
+var Operation = require('../models/operation').Operation;
+var TreePage = require('../models/tree_page').TreePage;
+
+/*
+ * Constructor
+ *
+ * This is the object exported by the file
+ *
+ */
+
+var UrlStorageAdapter = function(opts) {
+  this.opts = opts || {};
+};
+
+/*
+ * Methods
+ */
+
+UrlStorageAdapter.prototype.storePost = function(post, cb) {
+  var operation = new Operation(post);
+  operation.save(function(err, operation) {
+    if (err) {
+      console.log("Unable to save operation: " + err);
+    }
+    this.updateHtml(operation, cb);
+  });
+}
+
+UrlStorageAdapter.prototype.updateHtml = function(operation, cb) {
+  TreePage.findOne({ treeUrl: operation.treeUrl }, function(err, treePage) {
+    if (err) {
+      console.log('Unable to update html based on operation: ' + err);
+    }
+
+    // Apply operation to the currentHtml
+    // FIXME: concurrent operations. We need some notion of a queue.
+    // In other words, don't perform a new operation before a previous
+    // operation is complete.
+    var currentHtml = treePage.treeHtml;
+    treePage.treeHtml = OperationProcessor.operate(operation, currentHtml);
+    treePage.save();
+    cb(treePage);
+  });
+}
+
+exports.UrlStorageAdapter = UrlStorageAdapter;

--- a/app/tree-adapters/url_storage.js
+++ b/app/tree-adapters/url_storage.js
@@ -50,6 +50,16 @@ UrlStorageAdapter.prototype.save = function(post, cb) {
   });
 };
 
+UrlStorageAdapter.prototype.fetch = function(key, cb) {
+  TreePage.findOne({ treeKey: key }, function(err, treePage) {
+    if (err) {
+      console.log('Unable to fetch tree page: ' + err);
+    }
+
+    cb(err, treePage);
+  });
+}
+
 UrlStorageAdapter.prototype.updateHtml = function(operation, cb) {
   TreePage.findOne({ treeUrl: operation.treeUrl }, function(err, treePage) {
     if (err) {


### PR DESCRIPTION
This should store tree pages in mongoDB and swap out the cache adapter. Also creating an operation processor adapter skeleton that should process each operation on the html.
